### PR TITLE
Prevent buffer overflows on bad DNS response data

### DIFF
--- a/src/network/dns_parse.c
+++ b/src/network/dns_parse.c
@@ -15,13 +15,13 @@ int __dns_parse(const unsigned char *r, int rlen, int (*callback)(void *, int, c
 	if (qdcount+ancount > 64) return -1;
 	while (qdcount--) {
 		while (p-r < rlen && *p-1U < 127) p++;
-		if (*p>193 || (*p==193 && p[1]>254) || p>r+rlen-6)
+		if (p>r+rlen-6 || *p>193 || (*p==193 && p[1]>254))
 			return -1;
 		p += 5 + !!*p;
 	}
 	while (ancount--) {
 		while (p-r < rlen && *p-1U < 127) p++;
-		if (*p>193 || (*p==193 && p[1]>254) || p>r+rlen-6)
+		if (p>r+rlen-12 || *p>193 || (*p==193 && p[1]>254))
 			return -1;
 		p += 1 + !!*p;
 		len = p[8]*256 + p[9];

--- a/src/network/dns_parse.c
+++ b/src/network/dns_parse.c
@@ -15,7 +15,7 @@ int __dns_parse(const unsigned char *r, int rlen, int (*callback)(void *, int, c
 	if (qdcount+ancount > 64) return -1;
 	while (qdcount--) {
 		while (p-r < rlen && *p-1U < 127) p++;
-		if (p>r+rlen-6 || *p>193 || (*p==193 && p[1]>254))
+		if (p>r+rlen-5 || *p>193 || (*p==193 && p[1]>254))
 			return -1;
 		p += 5 + !!*p;
 	}


### PR DESCRIPTION
If the while in line 17 aborts because p-r == rlen then *p and p[1] are both out-of-bound of the response buffer. So in line 18 move the size check to the front to be checked first. The response must have 5 or 6 bytes left. The original code checked for 6 but that can give a false -1 return.

Similar in line 24 but here the response must have 11 or 12 bytes left for the later p[9] to not be out-of-bounds. Assuming results must have at least one byte of payload for the callback checking for 12 is OK.